### PR TITLE
Drop GHC 9.0 and older from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        ghc: ["8.6.5", "8.8.4", "8.10.7", "9.0.2", "9.2.8", "9.4.8", "9.6.7", "9.8.4", "9.10.2"]
+        ghc: ["9.2.8", "9.4.8", "9.6.7", "9.8.4", "9.10.2"]
 
         # Windows missing; no cross-platform CI scripts available yet.
         os: ["ubuntu-latest", "macos-latest"]


### PR DESCRIPTION
The new OrangeCrab starter project will use OverloadedRecordDot, but these ancient GHC's don't support that. Since OverloadedRecordDot is such a nice quality of life feature, let's just drop the ancient GHC's in CI.